### PR TITLE
Webhooks now display Whatsapp profile pic

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,3 +1,2 @@
 :: UPX is for compressing the binary. Original binary is around 10MiB.
 go build -ldflags="-s -w" -trimpath -o WA2DC.exe WA2DC.go
-upx -9 WA2DC.exe


### PR DESCRIPTION
- Added support for whatsapp profile pics to now be displayed instead of blank avatar
- Also slicing whatsapp messages to 1000 char long as its causing the bot to crash.

![unknown](https://user-images.githubusercontent.com/37984032/124601263-4257d080-de85-11eb-8a54-f823e9fc758a.png)

