### PR TITLE
Migrate to slash commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,146 +1,122 @@
 # Commands
-You can use the following commands only in `#control-room` created by the bot. Note that all the commands are case-insensitive. So, `list`, `LIST`, and `lIsT` would evaluate the same way.
+The following slash commands are provided by the bot.
 
-## pairWithCode
-Pairing with your phone number
-- Format: `pairWithCode <number with country code>`
+## `/pairwithcode`
+Pairs with your phone number.
+- Format: `/pairwithcode <number with country code>`
 - Examples:
-    - `pairWithCode 18001231234`: This would give you a code for you to enter on your phone and pair the bot with your phone number.
+    - `/pairwithcode 18001231234`: This would give you a code for you to enter on your phone and pair the bot with your phone number.
 
-## start
-Starts a new conversation. It can be used with a name or a phone number. 
-- Format: `start <number with country code or name>`
+## `/start`
+Starts a new conversation. It can be used with a name or a phone number.
+- Format: `/start <number with country code or name>`
 - Examples:
-    - `start 11231231234`: This would start a conversation with +1 123 123 1234.
-    - `start John Doe`: This would start a conversation with John Doe. It has to be in your contacts.
+    - `/start 11231231234`: This would start a conversation with +1 123 123 1234.
+    - `/start John Doe`: This would start a conversation with John Doe. It has to be in your contacts.
 
-## list
-Lists your contacts and groups. 
-- Format: `list <optional chat name to search>`
+## `/list`
+Lists your contacts and groups.
+- Format: `/list <optional chat name to search>`
 - Examples:
-    - `list`: This would list all of your contacts and groups.
-    - `list John`: This would list all of your contacts and groups that contain "John" in their name.
+    - `/list`: This would list all of your contacts and groups.
+    - `/list John`: This would list all of your contacts and groups that contain "John" in their name.
 
-## listWhitelist
+## `/listwhitelist`
 Shows all the whitelisted conversations. If no channel is whitelisted, the whitelist is disabled, meaning every message will be sent to Discord.
-- Format: `listWhitelist`
+- Format: `/listwhitelist`
 
-## addToWhitelist
+## `/addtowhitelist`
 Adds the given channel to the whitelist.
-- Format: `addToWhitelist #<channel name>`
+- Format: `/addtowhitelist <channel>`
 - Examples:
-    - `addToWhitelist #john-doe`: This would add John Doe to the whitelist, allowing them to send you a message if you have whitelist enabled.
+    - `/addtowhitelist #john-doe`: This would add John Doe to the whitelist, allowing them to send you a message if you have whitelist enabled.
 
-## removeFromWhitelist
+## `/removefromwhitelist`
 Removes the given channel from the whitelist.
-- Format: `removeFromWhitelist #<channel name>`
+- Format: `/removefromwhitelist <channel>`
 - Examples:
-    - `removeFromWhitelist #john-doe`: This would remove John Doe from the whitelist, preventing them to send you a message if you have whitelist enabled.
+    - `/removefromwhitelist #john-doe`: This would remove John Doe from the whitelist, preventing them to send you a message if you have whitelist enabled.
 
-## resync
+## `/resync`
 Re-syncs your contacts and groups, and renames channels. Can be used when the bot can't find your desired contact or group.
-- Format: `resync`
+- Format: `/resync`
 
-## enableWAUpload
+## `/wauploadenabled <enabled>`
 When enabled (enabled by default), the files received from Discord will be uploaded to WhatsApp, instead of providing a link to the attachment. File uploads takes longer and consumes more data.
-- Format: `enableWAUpload`
+- Format: `/enablewaupload <True|False>`
 
-## disableWAUpload
-When disabled (enabled by default), the files received from Discord will be sent as links to WhatsApp, instead of uploading them as a file. Providing links takes shorter and consumes less data.
-- Format: `disableWAUpload`
-
-## setDCPrefix
+## `/setdcprefix`
 When set (your username by default), the prefix will be added to messages sent to WhatsApp from Discord.
-- Format: `setDCPrefix`
+- Format: `/setdcprefix`
 
-## enableDCPrefix
+## `/dcprefixenabled <enabled>`
 When enabled (disabled by default), your Discord username will be added to messages sent to WhatsApp from Discord.
-- Format: `enableDCPrefix`
+- Format: `/dcprefixenabled <True|False>`
 
-## disableDCPrefix
-When disabled (disabled by default), your Discord username won't be added to messages sent to WhatsApp from Discord.
-- Format: `disableDCPrefix`
-
-## enableWAPrefix
+## `/waprefixenabled <enabled>`
 When enabled (disabled by default), WhatsApp names will be added to messages sent to Discord from WhatsApp. (Note that the bot already sets the username to the message sender's name)
-- Format: `enableWAPrefix`
+- Format: `/waprefixenabled <True|False>`
 
-## disableWAPrefix
-When disabled (disabled by default), WhatsApp names won't be added to messages sent to Discord from WhatsApp. (Note that the bot already sets the username to the message sender's name)
-- Format: `disableWAPrefix`
+## `/localdownloadsenabled <enabled>`
+When enabled, the bot downloads files larger than 8MB to your download location. See `/getdownloaddir` for your download location.
+- Format: `/localdownloadsenabled <True|False>`
 
-## enableLocalDownloads
-When enabled, the bot downloads files larger than 8MB to your download location. See `getDownloadDir` for your download location.
-- Format: `enableLocalDownloads`
-
-## disableLocalDownloads
-When enabled, the bot notifies you about receiving a file larger than 8MB.
-- Format: `disableLocalDownloads`
-
-## getDownloadMessage
+## `/getdownloadmessage`
 Prints out the download message. This message is printed when you receive a file larger than 8MB and it is downloaded.
-- Format: `getDownloadMessage`
+- Format: `/getdownloadmessage`
 - Default: *"Downloaded a file larger than 8MB, check it out at {abs}"*
 
-## setDownloadMessage
-Prints out the download message. This message is printed when you receive a file larger than 8MB and it is downloaded. There are keywords that you can use, `{abs}`: Downloaded file's absolute path, `{resolvedDownloadDir}`: Download directory's resolved path, `{downloadDir}`: unedited download directory, `{fileName}`: Downloaded file's name.
-- Format: `setDownloadMessage <your message here>`
+## `/setdownloadmessage`
+Prints out the download message. This message is printed when you receive a file larger than 8MB and it is downloaded. There are keywords that you can use, `/{abs}`: Downloaded file's absolute path, `/{resolvedDownloadDir}`: Download directory's resolved path, `/{downloadDir}`: unedited download directory, `/{fileName}`: Downloaded file's name.
+- Format: `/setdownloadmessage <your message here>`
 - Examples:
-    - `setDownloadMessage Received a file. The file name is {fileName}`
-    - `setDownloadMessage Received a file. Download it from local file server http://localhost:8080/WA2DC/{fileName}`: Note that files aren't hosted by the bot, you'll have to do it yourself if you have such a need.
-    - `setDownloadMessage Received a file. Information: Absolute path: {abs}, Resolved download directory: {resolvedDownloadDir}, Download directory: {downloadDir}, Filename: {fileName}`
+    - `/setdownloadmessage Received a file. The file name is {fileName}`
+    - `/setdownloadmessage Received a file. Download it from local file server http://localhost:8080/WA2DC/{fileName}`: Note that files aren't hosted by the bot, you'll have to do it yourself if you have such a need.
+    - `/setdownloadmessage Received a file. Information: Absolute path: {abs}, Resolved download directory: {resolvedDownloadDir}, Download directory: {downloadDir}, Filename: {fileName}`
 
-## getDownloadDir
+## `/getdownloaddir`
 Prints out the download directory.
-- Format: `getDownloadDir`
-- Default: `./downloads`: This means the bot will save files to the downloads folder inside bot's folder.
+- Format: `/getdownloaddir`
+- Default: `/./downloads`: This means the bot will save files to the downloads folder inside bot's folder.
 
-## setDownloadDir
+## `/setdownloaddir`
 Sets the download directory.
-- Format: `setDownloadDir <desired save path>`
+- Format: `/setdownloaddir <desired save path>`
 - Examples:
-    - `setDownloadDir C:\Users\<your username>\Downloads`: Downloads files to your usual Windows downloads folder
-    - `setDownloadDir ./downloads`: Downloads files to Downloads folder in your bot's location.
+    - `/setdownloaddir C:\Users\<your username>\Downloads`: Downloads files to your usual Windows downloads folder
+    - `/setdownloaddir ./downloads`: Downloads files to Downloads folder in your bot's location.
 
-## enablePublishing
+## `/publishingenabled <enabled>`
 Enables publishing messages sent to news channels automatically. By default, the bot won't notify news channel followers. With this option, you can send the message to the channel followers.
-- Format: `enablePublishing`
+- Format: `/publishingenabled <True|False>`
 
-## disablePublishing
-Disables publishing messages sent to news channels automatically.
-- Format: `disablePublishing`
-
-## enableChangeNotifications
+## `/changenotificationsenabled <enabled>`
 Enables profile picture change and status update notifications.
-- Format: `enableChangeNotifications`
+- Format: `/changenotificationsenabled <True|False>`
 
-## disableChangeNotifications
-Disables profile picture change and status update notifications.
-- Format: `disableChangeNotifications`
-
-## oneWay
+## `/oneway`
 Turns on one-way communication.
-- Format: `oneWay <discord|whatsapp|disabled>`
+- Format: `/oneway <discord|whatsapp|disabled>`
 - Examples:
-    - `oneWay discord`: would only send messages coming from WhatsApp to Discord, but not the other way.
+    - `/oneway discord`: would only send messages coming from WhatsApp to Discord, but not the other way.
 
-## autoSaveInterval
+## `/autosaveinterval`
 Changes the auto save interval to the number of seconds you provide.
-- Format: `autoSaveInterval <seconds>`
-- Example: `autoSaveInterval 60`
+- Format: `/autosaveinterval <seconds>`
+- Example: `/autosaveinterval 60`
 
-## lastMessageStorage
+## `/lastmessagestorage`
 Changes the last message storage size to the number provide. Last message storage size determines the number of last messages you can reply to. A value of 1000 would mean, you can react or reply to last 1000 messages received or sent. 
-- Format: `lastMessageStorage <size>`
-- Example: `lastMessageStorage 1000`
+- Format: `/lastmessagestorage <size>`
+- Example: `/lastmessagestorage 1000`
 
-## redirectWebhooks
+## `/redirectwebhooks`
 Allows sending webhook messages to be redirected to WhatsApp.
-- Format: `redirectWebhooks <yes|no>`
+- Format: `/redirectwebhooks <True|False>`
 - Examples:
-    - `redirectWebhooks yes`: Would redirect webhook messages to WhatsApp.
-    - `redirectWebhooks no`: Would not redirect webhook messages to WhatsApp.
+    - `/redirectwebhooks True`: Would redirect webhook messages to WhatsApp.
+    - `/redirectwebhooks False`: Would not redirect webhook messages to WhatsApp.
 
-## ping
+## `/ping`
 Replies back with *"Pong <Now - Time Message Sent>"ms*. It basically shows the bot's ping with the server. An unsynced date and time on your computer may cause big or even negative ping results, however, it doesn't mean you got negative ping or 10mins of lag, rather it is the Discord's time and your computer's time difference plus your ping.
-- Format: `ping`
+- Format: `/ping`

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
     "@whiskeysockets/baileys": "^6.7.8",
-    "discord.js": "^13.16.0",
+    "discord.js": "^14.19.3",
     "pino": "^8.14.1",
     "pkg-fetch": "^3.5.2",
     "qrcode": "^1.5.3"

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1,4 +1,17 @@
-const { Client, Events, GatewayIntentBits } = require('discord.js');
+const {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  Client,
+  Collection,
+  ComponentType,
+  Events,
+  GatewayIntentBits,
+  MessageFlags,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+} = require('discord.js');
 
 const state = require('./state.js');
 const utils = require('./utils.js');
@@ -21,7 +34,7 @@ client.on(Events.ClientReady, async () => {
   await setControlChannel();
 });
 
-client.on(Events.ChannelDelete, async (channel) => {
+client.on(Events.ChannelDelete, (channel) => {
   const jid = utils.discord.channelIdToJid(channel.id);
   delete state.chats[jid];
   delete state.goccRuns[jid];
@@ -135,240 +148,487 @@ client.on('whatsappCall', async ({ call, jid }) => {
   }
 });
 
-const commands = {
-  async ping(message) {
-    controlChannel.send(`Pong ${Date.now() - message.createdTimestamp}ms!`);
+const commands = [
+  {
+    data: new SlashCommandBuilder()
+      .setName('ping')
+      .setDescription("Displays the bot's ping."),
+    async execute(interaction) {
+      await interaction.reply(`Pong! (${Date.now() - interaction.createdTimestamp} ms)`);
+    },
   },
-  async pairwithcode(_message, params) {
-    if (params.length !== 1) {
-      await controlChannel.send('Please enter your number. Usage: `pairWithCode <number>`. Don\'t use "+" or any other special characters.');
-      return;
+  {
+    data: new SlashCommandBuilder()
+      .setName('pairwithcode')
+      .setDescription('Pairs with your phone number.')
+      .addIntegerOption(option =>
+        option
+          .setName('number')
+          .setDescription('Your number, including the country code but excluding "+" and other special characters.')
+          .setRequired(true)),
+    async execute(interaction) {
+      await interaction.deferReply();
+      const code = await state.waClient.requestPairingCode(
+        interaction.options.getInteger('number')
+      );
+      await interaction.editReply(`Your pairing code is: \`${code}\``);
     }
-
-    const code = await state.waClient.requestPairingCode(params[0]);
-    await controlChannel.send(`Your pairing code is: ${code}`);
   },
-  async start(_message, params) {
-    if (!params.length) {
-      await controlChannel.send('Please enter a phone number or name. Usage: `start <number with country code or name>`.');
-      return;
-    }
+  {
+    data: new SlashCommandBuilder()
+      .setName('start')
+      .setDescription('Starts a new conversation with a WhatsApp group or contact.')
+      .addStringOption(option =>
+        option
+          .setName('name-or-number')
+          .setDescription('The name or phone number of the chat.')
+          .setRequired(true)),
+    async execute(interaction) {
+      await interaction.deferReply();
 
-    // eslint-disable-next-line no-restricted-globals
-    const jid = utils.whatsapp.toJid(params.join(' '));
-    if (!jid) {
-      await controlChannel.send(`Couldn't find \`${params.join(' ')}\`.`);
-      return;
-    }
-    await utils.discord.getOrCreateChannel(jid);
+      const name = interaction.options.getString('name-or-number');
+      const jid = utils.whatsapp.toJid(name);
+      if (!jid) {
+        await interaction.editReply(`Couldn't find \`${name}\`.`);
+        return;
+      }
 
-    if (state.settings.Whitelist.length) {
+      await utils.discord.getOrCreateChannel(jid);
+
+      if (state.settings.Whitelist.length) {
+        state.settings.Whitelist.push(jid);
+      }
+
+      await interaction.editRreply(`Started conversation with \`${name}\`.`);
+    }
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('list')
+      .setDescription('Lists your WhatsApp chats.')
+      .addStringOption(option =>
+        option
+          .setName('filter')
+          .setDescription('Filter by the given string (case-insensitive).')),
+    async execute(interaction) {
+      await interaction.deferReply();
+
+      let contacts = utils.whatsapp.contacts();
+
+      const filterString = interaction.options.getString('filter');
+      if (filterString) {
+        contacts = contacts.filter((name) => name.toLowerCase().includes(filterString));
+      }
+
+      contacts = contacts.sort((a, b) => a.localeCompare(b));
+
+      if (contacts.length === 0) {
+        await interaction.editReply('No results were found.');
+        return;
+      }
+
+      const page_size = 10;
+
+      const prevButton = new ButtonBuilder()
+        .setCustomId('prev')
+        .setLabel('Previous')
+        .setEmoji('⬅️')
+        .setStyle(ButtonStyle.Primary)
+
+      const nextButton = new ButtonBuilder()
+        .setCustomId('next')
+        .setLabel('Next')
+        .setEmoji('➡️')
+        .setStyle(ButtonStyle.Primary)
+
+      const generateContent = startIndex => {
+        return `Not the whole list? Refresh your contacts by running \`/resync\`.\`\`\`\n${
+          contacts.slice(startIndex, startIndex + page_size).join('\n')
+        }\`\`\`page ${startIndex / page_size + 1}/${Math.ceil(contacts.length / page_size)}`;
+      }
+
+      const collector = await interaction.editReply({
+        content: generateContent(0),
+        components: contacts.length > page_size
+          ? [new ActionRowBuilder().addComponents(nextButton)]
+          : [],
+      }).then(
+          message => message.createMessageComponentCollector({componentType: ComponentType.Button})
+      );
+
+      if (contacts.length <= page_size) {
+        return;
+      }
+
+      let currentIndex = 0;
+      collector.on('collect', async i => {
+        if (i.user.id !== interaction.user.id) {
+          return;
+        }
+
+        currentIndex += i.customId === 'prev' ? -page_size : page_size;
+
+        await i.update({
+          content: generateContent(currentIndex),
+          components: [
+              new ActionRowBuilder()
+              .addComponents(
+                ...(currentIndex ? [prevButton] : []),
+                ...(currentIndex + page_size < contacts.length ? [nextButton] : [])
+              ),
+          ]
+        });
+      });
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('addtowhitelist')
+      .setDescription('Adds a channel to the whitelist.')
+      .addChannelOption(option =>
+        option
+          .setName('channel')
+          .setDescription('The channel to add.')
+          .setRequired(true)),
+    async execute(interaction) {
+      await interaction.deferReply();
+
+      const channel = interaction.options.getChannel('channel');
+
+      const jid = utils.discord.channelIdToJid(channel.id);
+      if (!jid) {
+        await controlChannel.send("Couldn't find a chat with the given channel.");
+        return;
+      }
+
       state.settings.Whitelist.push(jid);
-    }
+      await interaction.editReply('Added to the whitelist!');
+    },
   },
-  async list(_message, params) {
-    let contacts = utils.whatsapp.contacts();
-    if (params) { contacts = contacts.filter((name) => name.toLowerCase().includes(params.join(' '))); }
-    contacts = contacts.sort((a, b) => a.localeCompare(b)).join('\n');
-    const message = utils.discord.partitionText(
-      contacts.length
-        ? `${contacts}\n\nNot the whole list? You can refresh your contacts by typing \`resync\``
-        : 'No results were found.',
-    );
-    while (message.length !== 0) {
-      // eslint-disable-next-line no-await-in-loop
-      await controlChannel.send(message.shift());
-    }
-  },
-  async addtowhitelist(message, params) {
-    const channelID = /<#(\d*)>/.exec(message)?.[1];
-    if (params.length !== 1 || !channelID) {
-      await controlChannel.send('Please enter a valid channel name. Usage: `addToWhitelist #<target channel>`.');
-      return;
-    }
+  {
+    data: new SlashCommandBuilder()
+      .setName('removefromwhitelist')
+      .setDescription('Removes a channel from the whitelist.')
+      .addChannelOption(option =>
+        option
+          .setName('channel')
+          .setDescription('The channel to remove.')
+          .setRequired(true)),
+    async execute(interaction) {
+      await interaction.deferReply();
 
-    const jid = utils.discord.channelIdToJid(channelID);
-    if (!jid) {
-      await controlChannel.send("Couldn't find a chat with the given channel.");
-      return;
-    }
+      const channel = interaction.options.getChannel('channel');
 
-    state.settings.Whitelist.push(jid);
-    await controlChannel.send('Added to the whitelist!');
-  },
-  async removefromwhitelist(message, params) {
-    const channelID = /<#(\d*)>/.exec(message)?.[1];
-    if (params.length !== 1 || !channelID) {
-      await controlChannel.send('Please enter a valid channel name. Usage: `removeFromWhitelist #<target channel>`.');
-      return;
-    }
+      const jid = utils.discord.channelIdToJid(channel.id);
+      if (!jid) {
+        await controlChannel.send("Couldn't find a chat with the given channel.");
+        return;
+      }
 
-    const jid = utils.discord.channelIdToJid(channelID);
-    if (!jid) {
-      await controlChannel.send("Couldn't find a chat with the given channel.");
-      return;
-    }
+      state.settings.Whitelist = state.settings.Whitelist.filter((el) => el !== jid);
+      await interaction.editReply('Removed from the whitelist!');
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('listwhitelist')
+      .setDescription('Shows the whitelist.'),
+    async execute(interaction) {
+      await interaction.deferReply();
+      await interaction.editReply(
+        state.settings.Whitelist.length
+          ? `\`\`\`${state.settings.Whitelist.map(
+              (jid) => utils.whatsapp.jidToName(jid)
+            ).join('\n')}\`\`\``
+          : 'Whitelist is empty/inactive.',
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('setdcprefix')
+      .setDescription('Sets the prefix for messages sent to Discord.')
+      .addStringOption(option =>
+        option
+          .setName('prefix')
+          .setDescription('The prefix to set. Omit to reset to default.')),
+    async execute(interaction) {
+      state.settings.DiscordPrefixText = interaction.options.getString('prefix');
+      await interaction.reply(
+        `Discord prefix is set to ${
+          state.settings.DiscordPrefixText
+            ? `\`${state.settings.DiscordPrefixText}\``
+            : 'your Discord username'
+        }!`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('dcprefixenabled')
+      .setDescription('Sets whether the Discord username prefix is enabled.')
+      .addBooleanOption(option =>
+        option
+          .setName('enabled')
+          .setDescription('Whether to enable or disable.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.DiscordPrefix = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `Discord username prefix ${state.settings.DiscordPrefix ? 'enabled' : 'disabled'}!`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('waprefixenabled')
+      .setDescription('Sets whether the WhatsApp name prefix is enabled.')
+      .addBooleanOption(option =>
+        option
+          .setName('enabled')
+          .setDescription('Whether to enable or disable.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.WAGroupPrefix = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `WhatsApp name prefix ${state.settings.WAGroupPrefix ? 'enabled' : 'disabled'}!`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+          .setName('wauploadenabled')
+          .setDescription('Sets whether uploading files to WhatsApp is enabled.')
+          .addBooleanOption(option =>
+            option
+              .setName('enabled')
+              .setDescription('Whether to enable or disable.')
+              .setRequired(true)),
+    async execute(interaction) {
+      state.settings.UploadAttachments = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `Uploading files to WhatsApp has been ${state.settings.UploadAttachments ? 'enabled' : 'disabled'}!`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('help')
+      .setDescription('Shows information on how to use the bot.'),
+    async execute(interaction) {
+      await interaction.reply(
+        'See all the available commands at https://fklc.github.io/WhatsAppToDiscord/#/commands'
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('resync')
+      .setDescription('Resynchronizes WhatsApp contacts and groups and renames channels as needed.'),
+    async execute(interaction) {
+      await interaction.deferReply();
+      await state.waClient.authState.keys.set({
+        'app-state-sync-version': { critical_unblock_low: null },
+      });
+      await state.waClient.resyncAppState(['critical_unblock_low']);
+      for (const [jid, attributes] of Object.entries(await state.waClient.groupFetchAllParticipating())) { state.waClient.contacts[jid] = attributes.subject; }
+      await utils.discord.renameChannels();
+      await interaction.editReply('Re-synced!');
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+          .setName('localdownloadsenabled')
+          .setDescription('Sets whether local downloads are enabled.')
+          .addBooleanOption(option =>
+            option
+              .setName('enabled')
+              .setDescription('Whether to enable or disable.')
+              .setRequired(true)),
+    async execute(interaction) {
+      state.settings.LocalDownloads = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `Local downloads for files larger than 8MB been ${state.settings.LocalDownloads ? 'enabled' : 'disabled'}!`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('getdownloadmessage')
+      .setDescription('Shows the current download message format.'),
+    async execute(interaction) {
+      await interaction.reply(`The download message format is set to: \`${state.settings.LocalDownloadMessage}\``);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('setdownloadmessage')
+      .setDescription('Sets the download message format.')
+      .addStringOption(option =>
+        option
+          .setName('format')
+          .setDescription('The download message format.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.LocalDownloadMessage = interaction.options.getString('format');
+      await interaction.reply(`Set download message format to: \`${state.settings.LocalDownloadMessage}\``);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('getdownloaddir')
+      .setDescription('Shows the current download directory path.'),
+    async execute(interaction) {
+      await interaction.reply(`The download path is set to: \`${state.settings.DownloadDir}\``);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('setdownloaddir')
+      .setDescription('Sets the download directory path.')
+      .addStringOption(option =>
+        option
+          .setName('path')
+          .setDescription('The path to the new download directory.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.DownloadDir = interaction.options.getString('path');
+      await interaction.reply(`Set download path to: \`${state.settings.DownloadDir}\``);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('publishingenabled')
+      .setDescription('Sets whether publishing messages sent to news channels is enabled.')
+      .addBooleanOption(option =>
+        option
+          .setName('enabled')
+          .setDescription('Whether to enable or disable.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.Publish = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `${state.settings.Publish ? 'Enabled' : 'Disabled'} publishing messages sent to news channels.`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('changenotificationsenabled')
+      .setDescription('Sets whether profile picture change and status update notifications are enabled.')
+      .addBooleanOption(option =>
+        option
+          .setName('enabled')
+          .setDescription('Whether to enable or disable.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.ChangeNotifications = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `${state.settings.Publish ? 'Enabled' : 'Disabled'} profile picture change and status update notifications.`
+      );
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('autosaveinterval')
+      .setDescription('Sets the autosave interval.')
+      .addIntegerOption(option =>
+        option
+          .setName('interval')
+          .setDescription('The new autosave interval, in seconds.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.autoSaveInterval = interaction.options.getInteger('interval');
+      await interaction.reply(`Changed autosave interval to ${state.settings.autoSaveInterval}.`);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('lastmessagestorage')
+      .setDescription('Sets the last message storage size.')
+      .addIntegerOption(option =>
+        option
+          .setName('size')
+          .setDescription('The new size.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.lastMessageStorage = interaction.options.getInteger('size');
+      await interaction.reply(`Changed last message storage size to ${state.settings.lastMessageStorage}.`);
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('oneway')
+      .setDescription('Configures one-way/two-way communication.')
+      .addIntegerOption(option =>
+        option
+          .setName('state')
+          .setDescription('The state.')
+          .setRequired(true)
+          .addChoices(
+            { name: 'Disabled; enable two-way communication', value: 0b11 },
+            { name: 'Only send messages to WhatsApp', value: 0b10 },
+            { name: 'Only send messages to Discord', value: 0b01 },
+          )),
+    async execute(interaction) {
+      state.settings.oneWay = interaction.options.getInteger('state');
+      if (state.settings.oneWay == 0b11) {
+        await interaction.reply('Two-way communication is now enabled.');
+      } else {
+        await interaction.reply(
+          `Messages will only be sent to ${state.settings.oneWay == 0b10 ? 'WhatsApp' : 'Discord'}.`
+        );
+      }
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName('redirectwebhooks')
+      .setDescription('Sets whether webhook redirection is enabled.')
+      .addBooleanOption(option =>
+        option
+          .setName('enabled')
+          .setDescription('Whether to enable or disable.')
+          .setRequired(true)),
+    async execute(interaction) {
+      state.settings.redirectWebhooks = interaction.options.getBoolean('enabled');
+      await interaction.reply(
+        `${state.settings.Publish ? 'Enabled' : 'Disabled'} redirecting webhooks.`
+      );
+    },
+  },
+];
 
-    state.settings.Whitelist = state.settings.Whitelist.filter((el) => el !== jid);
-    await controlChannel.send('Removed from the whitelist!');
-  },
-  async listwhitelist() {
-    await controlChannel.send(
-      state.settings.Whitelist.length
-        ? `\`\`\`${state.settings.Whitelist.map((jid) => utils.whatsapp.jidToName(jid)).join('\n')}\`\`\``
-        : 'Whitelist is empty/inactive.',
-    );
-  },
-  async setdcprefix(message, params) {
-    if (params.length !== 0) {
-      const prefix = message.content.split(' ').slice(1).join(' ');
-      state.settings.DiscordPrefixText = prefix;
-      await controlChannel.send(`Discord prefix is set to ${prefix}!`);
-    } else {
-      state.settings.DiscordPrefixText = null;
-      await controlChannel.send('Discord prefix is set to your discord username!');
-    }
-  },
-  async enabledcprefix() {
-    state.settings.DiscordPrefix = true;
-    await controlChannel.send('Discord username prefix enabled!');
-  },
-  async disabledcprefix() {
-    state.settings.DiscordPrefix = false;
-    await controlChannel.send('Discord username prefix disabled!');
-  },
-  async enablewaprefix() {
-    state.settings.WAGroupPrefix = true;
-    await controlChannel.send('WhatsApp name prefix enabled!');
-  },
-  async disablewaprefix() {
-    state.settings.WAGroupPrefix = false;
-    await controlChannel.send('WhatsApp name prefix disabled!');
-  },
-  async enablewaupload() {
-    state.settings.UploadAttachments = true;
-    await controlChannel.send('Enabled uploading files to WhatsApp!');
-  },
-  async disablewaupload() {
-    state.settings.UploadAttachments = false;
-    await controlChannel.send('Disabled uploading files to WhatsApp!');
-  },
-  async help() {
-    await controlChannel.send('See all the available commands at https://fklc.github.io/WhatsAppToDiscord/#/commands');
-  },
-  async resync() {
-    await state.waClient.authState.keys.set({
-      'app-state-sync-version': { critical_unblock_low: null },
-    });
-    await state.waClient.resyncAppState(['critical_unblock_low']);
-    for (const [jid, attributes] of Object.entries(await state.waClient.groupFetchAllParticipating())) { state.waClient.contacts[jid] = attributes.subject; }
-    await utils.discord.renameChannels();
-    await controlChannel.send('Re-synced!');
-  },
-  async enablelocaldownloads() {
-    state.settings.LocalDownloads = true;
-    await controlChannel.send(`Enabled local downloads. You can now download files larger than 8MB.`);
-  },
-  async disablelocaldownloads() {
-    state.settings.LocalDownloads = false;
-    await controlChannel.send(`Disabled local downloads. You won't be able to download files larger than 8MB.`);
-  },
-  async getdownloadmessage() {
-    await controlChannel.send(`Download message format is set to "${state.settings.LocalDownloadMessage}"`);
-  },
-  async setdownloadmessage(message) {
-    state.settings.LocalDownloadMessage = message.content.split(' ').slice(1).join(' ');
-    await controlChannel.send(`Set download message format to "${state.settings.LocalDownloadMessage}"`);
-  },
-  async getdownloaddir() {
-    await controlChannel.send(`Download path is set to "${state.settings.DownloadDir}"`);
-  },
-  async setdownloaddir(message) {
-    state.settings.DownloadDir = message.content.split(' ').slice(1).join(' ');
-    await controlChannel.send(`Set download path to "${state.settings.DownloadDir}"`);
-  },
-  async enablepublishing() {
-    state.settings.Publish = true;
-    await controlChannel.send(`Enabled publishing messages sent to news channels.`);
-  },
-  async disablepublishing() {
-    state.settings.Publish = false;
-    await controlChannel.send(`Disabled publishing messages sent to news channels.`);
-  },
-  async enablechangenotifications() {
-    state.settings.ChangeNotifications = true;
-    await controlChannel.send(`Enabled profile picture change and status update notifications.`);
-  },
-  async disablechangenotifications() {
-    state.settings.ChangeNotifications = false;
-    await controlChannel.send(`Disabled profile picture change and status update notifications.`);
-  },
-  async autosaveinterval(_message, params) {
-    if (params.length !== 1) {
-      await controlChannel.send("Usage: autoSaveInterval <seconds>\nExample: autoSaveInterval 60");
-      return;
-    }
-    state.settings.autoSaveInterval = +params[0];
-    await controlChannel.send(`Changed auto save interval to ${params[0]}.`);
-  },
-  async lastmessagestorage(_message, params) {
-    if (params.length !== 1) {
-      await controlChannel.send("Usage: lastMessageStorage <size>\nExample: lastMessageStorage 1000");
-      return;
-    }
-    state.settings.lastMessageStorage = +params[0];
-    await controlChannel.send(`Changed last message storage size to ${params[0]}.`);
-  },
-  async oneway(_message, params) {
-    if (params.length !== 1) {
-      await controlChannel.send("Usage: oneWay <discord|whatsapp|disabled>\nExample: oneWay whatsapp");
-      return;
-    }
-    
-    if (params[0] === "disabled") {
-      state.settings.oneWay = 0b11;
-      await controlChannel.send(`Two way communication is enabled.`);
-    } else if (params[0] === "whatsapp") {
-      state.settings.oneWay = 0b10;
-      await controlChannel.send(`Messages will be only sent to WhatsApp.`);
-    } else if (params[0] === "discord") {
-      state.settings.oneWay = 0b01;
-      await controlChannel.send(`Messages will be only sent to Discord.`);
-    } else {
-      await controlChannel.send("Usage: oneWay <discord|whatsapp|disabled>\nExample: oneWay whatsapp");
-    }
-  },
-  async redirectwebhooks(_message, params) {
-    if (params.length !== 1) {
-      await controlChannel.send("Usage: redirectWebhooks <yes|no>\nExample: redirectWebhooks yes");
-      return;
-    }
+client.on(Events.InteractionCreate, async (interaction) =>  {
+  if (!interaction.isChatInputCommand()) return;
 
-    state.settings.redirectWebhooks = params[0] === "yes";
-    await controlChannel.send(`Redirecting webhooks is set to ${state.settings.redirectWebhooks}.`);
-  },
-  async unknownCommand(message) {
-    await controlChannel.send(`Unknown command: \`${message.content}\`\nType \`help\` to see available commands`);
-  },
-};
+  const execute = interaction.client.commands.get(interaction.commandName);
 
-client.on(Events.MessageCreate, async (message) => {
-  console.log(message, state.dcClient.user.id);
-  if (message.author === client.user || message.applicationId === client.user.id || (message.webhookId != null && !state.settings.redirectWebhooks)) {
+  if (!execute) {
+    console.error(`Unknown command: \`${interaction.commandName}\`\nRun \`/help\` to see available commands.`);
     return;
   }
 
-  if (message.channel === controlChannel) {
-    const command = message.content.toLowerCase().split(' ');
-    await (commands[command[0]] || commands.unknownCommand)(message, command.slice(1));
-  } else {
-    const jid = utils.discord.channelIdToJid(message.channel.id);
-    if (jid == null) {
-      return;
-    }
+  await execute(interaction);
+});
 
-    state.waClient.ev.emit('discordMessage', { jid, message });
+client.on(Events.MessageCreate, (message) => {
+  console.log(message, state.dcClient.user.id);
+  if (
+      message.channel === controlChannel ||
+      message.author === client.user ||
+      message.applicationId === client.user.id ||
+      (message.webhookId != null && !state.settings.redirectWebhooks)
+  ) {
+    return;
   }
+
+  const jid = utils.discord.channelIdToJid(message.channel.id);
+  if (jid == null) {
+    return;
+  }
+
+  state.waClient.ev.emit('discordMessage', { jid, message });
 });
 
 client.on(Events.MessageUpdate, async (_, message) => {
@@ -426,7 +686,23 @@ client.on(Events.MessageReactionRemove, async (reaction, user) => {
 
 module.exports = {
   start: async () => {
+    const rest = new REST().setToken(state.settings.Token);
+
+    const raw_commands = [];
+    client.commands = new Collection();
+
+    for (const command of commands) {
+      raw_commands.push(command.data.toJSON());
+      client.commands.set(command.data.name, command.execute);
+    }
+
     await client.login(state.settings.Token);
+
+    await rest.put(
+      Routes.applicationGuildCommands(client.user.id, state.settings.GuildID),
+      { body: raw_commands },
+    );
+
     return client;
   },
   setControlChannel,

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits } = require('discord.js');
+const { Client, Events, GatewayIntentBits } = require('discord.js');
 
 const state = require('./state.js');
 const utils = require('./utils.js');
@@ -17,11 +17,11 @@ const setControlChannel = async () => {
   controlChannel = await client.channels.fetch(state.settings.ControlChannelID).catch(() => null);
 };
 
-client.on('ready', async () => {
+client.on(Events.ClientReady, async () => {
   await setControlChannel();
 });
 
-client.on('channelDelete', async (channel) => {
+client.on(Events.ChannelDelete, async (channel) => {
   const jid = utils.discord.channelIdToJid(channel.id);
   delete state.chats[jid];
   delete state.goccRuns[jid];
@@ -352,7 +352,7 @@ const commands = {
   },
 };
 
-client.on('messageCreate', async (message) => {
+client.on(Events.MessageCreate, async (message) => {
   console.log(message, state.dcClient.user.id);
   if (message.author === client.user || message.applicationId === client.user.id || (message.webhookId != null && !state.settings.redirectWebhooks)) {
     return;
@@ -371,7 +371,7 @@ client.on('messageCreate', async (message) => {
   }
 });
 
-client.on('messageUpdate', async (_, message) => {
+client.on(Events.MessageUpdate, async (_, message) => {
   if (message.webhookId != null) {
     return;
   }
@@ -390,7 +390,7 @@ client.on('messageUpdate', async (_, message) => {
   state.waClient.ev.emit('discordEdit', { jid, message });
 })
 
-client.on('messageReactionAdd', async (reaction, user) => {
+client.on(Events.MessageReactionAdd, async (reaction, user) => {
   const jid = utils.discord.channelIdToJid(reaction.message.channel.id);
   if (jid == null) {
     return;
@@ -407,7 +407,7 @@ client.on('messageReactionAdd', async (reaction, user) => {
   state.waClient.ev.emit('discordReaction', { jid, reaction, removed: false });
 });
 
-client.on('messageReactionRemove', async (reaction, user) => {
+client.on(Events.MessageReactionRemove, async (reaction, user) => {
   const jid = utils.discord.channelIdToJid(reaction.message.channel.id);
   if (jid == null) {
     return;

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1,14 +1,14 @@
-const { Client, Intents } = require('discord.js');
+const { Client, GatewayIntentBits } = require('discord.js');
 
 const state = require('./state.js');
 const utils = require('./utils.js');
 
 const client = new Client({
   intents: [
-    Intents.FLAGS.GUILDS,
-    Intents.FLAGS.GUILD_MESSAGES,
-    Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
-    Intents.FLAGS.MESSAGE_CONTENT,
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.MessageContent,
   ],
 });
 let controlChannel;

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,7 +1,7 @@
 const readline = require('readline');
 const fs = require('fs/promises');
 const path = require('path');
-const { Client, Intents } = require('discord.js');
+const { Client, GatewayIntentBits } = require('discord.js');
 
 const state = require('./state.js');
 
@@ -80,7 +80,7 @@ const storage = {
 const setup = {
   async setupDiscordChannels(token) {
     return new Promise((resolve) => {
-      const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
+      const client = new Client({ intents: [GatewayIntentBits.Guilds] });
       client.once('ready', () => {
         console.log(`Invite the bot using the following link: https://discordapp.com/oauth2/authorize?client_id=${client.user.id}&scope=bot&permissions=536879120`);
       });


### PR DESCRIPTION
[Discord has supported slash commands](https://discord.com/blog/slash-commands-are-here) for a number of years. Slash commands provide better UX with features such as autocompletion, on-the-spot documentation and argument validation. In the context of WA2DC, commands can also be run in channels other than `#control-room`, resulting in greater flexibility.

This PR rewrites parts of discordHandler.js to use slash commands instead of legacy text commands. Other relevant changes are as follows:
- Updated discord.js to 14.19.3. The version of discord.js currently used in WA2DC has a somewhat different API for building slash commands so updating it at this stage will probably save some maintenance burden in the future.
- Pairs of commands that enable and disable settings have each been merged into a single command that accepts a Boolean argument. E.g., `enableWAUpload` and `disableWAUpload` are now `/wauploadenabled <True/False>`. This is to reduce redundancy and avoid cluttering the list of commands.
- Prettified the output of certain commands, including adding pagination support for `/list`.
- Updated docs/commands.md according to the changes.

> [!NOTE]
> Marked as a draft because `/start` appears to be broken from my testing at the moment, possibly due to an issue in `utils.discord.getOrCreateChannel()`. I will investigate it soon.